### PR TITLE
Adds flex layout to contributors page

### DIFF
--- a/assets/css/contributor.css
+++ b/assets/css/contributor.css
@@ -21,3 +21,14 @@
     font-style: italic;
     opacity: .8;
 }
+
+.contributors-list {
+  display: inline-flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+}
+
+.contributor-card {
+  width: 15rem;
+}

--- a/contributor.html
+++ b/contributor.html
@@ -73,7 +73,7 @@
 
             profiles.forEach(({ name, github, twitter, avatarUrl }) => {
                 contributorsElement.innerHTML += `
-      <div class="mx-auto">
+      <div class="contributor-card m-1">
                 <div class="rounded-3xl overflow-visible shadow-xl max-w-[240px] h-[350px] my-3 p-4">
       <img src="${avatarUrl}"
         class="rounded-full border-solid border-white border-2 mt-3" />


### PR DESCRIPTION
This MR adds a flex layout to the contributors page. 

Resolves https://github.com/devvsakib/hacktoberfest-react-project/issues/76

Before:  
<img width="952" alt="Screen Shot 2022-10-21 at 1 00 54 PM" src="https://user-images.githubusercontent.com/2304077/197282636-a4b30acd-29ca-497c-aac3-af4ccf5ae675.png">

After:  
<img width="1785" alt="Screen Shot 2022-10-21 at 1 20 44 PM" src="https://user-images.githubusercontent.com/2304077/197282673-f20d39d3-bb8f-44d4-a031-613b6a0b3b11.png">
