### PR TITLE
Update screenshot positions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Hacktoberfest-React-Project
 
 ## About
-![PowerTheWeb Contributors](assets/powertheweb-contributors.png)
-
 ![PowerTheWeb Cover](assets/powertheweb-cover.png)
+
+![PowerTheWeb Contributors](assets/powertheweb-contributors.png)
 
 PowerTheWeb is an open-source project to help web developers make their road easy to become a successful web developer
 


### PR DESCRIPTION
In the previous PR for issue #123 the screenshots were in the wrong position. This fixes that so that the cover image is on top and the contributors image is on the bottom. Sorry for the mistake!